### PR TITLE
Add Windows install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, u
    source .venv/bin/activate
    ```
 2. Abhängigkeiten installieren
-   ```bash
-   bash install.sh
-   ```
+   - Linux/macOS:
+     ```bash
+     bash install.sh
+     ```
+   - Windows:
+     ```
+     install.bat
+     ```
 
 Alternativ können die Python-Abhängigkeiten auch manuell installiert werden:
 ```bash

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Run this script with administrator rights.
+REM Requires Chocolatey: https://chocolatey.org/install
+
+REM Install system dependencies
+choco install -y tesseract poppler
+
+REM Upgrade pip and install Python packages
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+


### PR DESCRIPTION
## Summary
- add install.bat for Windows users to install system and Python dependencies
- document Windows installation steps in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899b426a52c8320b2a7c9e6f7273b52