### PR TITLE
Add automatic Poppler path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, u
      ```
      install.bat
      ```
+     Falls Poppler nicht automatisch gefunden wird, kann der Pfad über die
+     Umgebungsvariable `POPPLER_PATH` angegeben werden.
 
 Alternativ können die Python-Abhängigkeiten auch manuell installiert werden:
 ```bash

--- a/app.py
+++ b/app.py
@@ -1,15 +1,51 @@
 import io
-from typing import List
+import os
+from pathlib import Path
+from typing import List, Optional
 
 import streamlit as st
 from pdf2image import convert_from_bytes
+from pdf2image.exceptions import PDFInfoNotInstalledError
 import pytesseract
 from fpdf import FPDF
 
 
+def _detect_poppler_path() -> Optional[str]:
+    """Try to locate the poppler binaries.
+
+    Returns the path to the poppler "bin" directory if found, otherwise
+    ``None``. On Windows a couple of common installation locations (including
+    the default Chocolatey path) are checked in addition to the optional
+    ``POPPLER_PATH`` environment variable.
+    """
+
+    env_path = os.environ.get("POPPLER_PATH")
+    if env_path and Path(env_path).exists():
+        return env_path
+
+    if os.name == "nt":
+        candidates = [
+            r"C:\\Program Files\\poppler\\bin",
+            r"C:\\Program Files (x86)\\poppler\\bin",
+            r"C:\\ProgramData\\chocolatey\\lib\\poppler\\tools",
+        ]
+        for path in candidates:
+            if Path(path).exists():
+                return path
+
+    return None
+
+
 def ocr_pdf(pdf_bytes: bytes, lang: str, psm: int, dpi: int) -> bytes:
     """Run OCR on a PDF and return a new PDF containing only recognized text."""
-    images = convert_from_bytes(pdf_bytes, dpi=dpi)
+    poppler_path = _detect_poppler_path()
+    try:
+        images = convert_from_bytes(pdf_bytes, dpi=dpi, poppler_path=poppler_path)
+    except PDFInfoNotInstalledError as exc:
+        raise RuntimeError(
+            "Poppler konnte nicht gefunden werden. Bitte installieren und den Pfad\n"
+            "über die Umgebungsvariable POPPLER_PATH angeben."
+        ) from exc
     all_text: List[str] = []
     config = f"--psm {psm}"
     for img in images:


### PR DESCRIPTION
## Summary
- detect common Poppler installation paths on Windows and support `POPPLER_PATH`
- surface clearer error when Poppler is missing
- document how to set `POPPLER_PATH` in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899b6f090cc83209f87394dfc4e8d63