### PR TITLE
chore: remove poppler dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, u
 ## Voraussetzungen
 
 - Python 3.10 oder neuer
-- Systempakete [`tesseract-ocr`](https://tesseract-ocr.github.io/tessdoc/Home.html) und [`poppler-utils`](https://poppler.freedesktop.org/) (werden für die Bildkonvertierung benötigt)
+- Systempaket [`tesseract-ocr`](https://tesseract-ocr.github.io/tessdoc/Home.html) (für die OCR-Erkennung)
 
 ## Installation
 
@@ -23,14 +23,11 @@ Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, u
      ```
      install.bat
      ```
-     Der Batch-Installer versucht zuerst, die benötigten Systempakete über
+     Der Batch-Installer versucht zuerst, das benötigte Systempaket über
      [Chocolatey](https://chocolatey.org) bzw. das Windows Paket-Tool
-     (`winget`) zu beziehen. Sollte kein Paketmanager vorhanden sein, können
-     [Tesseract](https://github.com/UB-Mannheim/tesseract/wiki) und die
-     [Poppler‑Binaries](https://github.com/oschwartz10612/poppler-windows/releases)
-     auch manuell installiert werden. In diesem Fall muss anschließend die
-     Umgebungsvariable `POPPLER_PATH` auf das `bin`‑Verzeichnis der Poppler-
-     Installation gesetzt werden.
+     (`winget`) zu beziehen. Sollte kein Paketmanager vorhanden sein, kann
+     [Tesseract](https://github.com/UB-Mannheim/tesseract/wiki) auch manuell
+     installiert werden.
 
 Alternativ können die Python-Abhängigkeiten auch manuell installiert werden:
 ```bash

--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Run this script with administrator rights.
-REM Installs Tesseract and Poppler on Windows.  The script first tries to
+REM Installs Tesseract on Windows.  The script first tries to
 REM use Chocolatey and falls back to Winget.  If neither package manager is
 REM available, a short manual installation hint is shown.
 
@@ -8,20 +8,16 @@ REM --- install system dependencies ---------------------------------------
 where choco >NUL 2>&1
 if %ERRORLEVEL% EQU 0 (
     echo Installing dependencies via Chocolatey...
-    choco install -y tesseract poppler
+    choco install -y tesseract
 ) else (
     where winget >NUL 2>&1
     if %ERRORLEVEL% EQU 0 (
         echo Installing dependencies via Winget...
         winget install -e --id UB-Mannheim.Tesseract-OCR
-        winget install -e --id mikespub.poppler
     ) else (
         echo Neither Chocolatey nor Winget could be found.
-        echo Please install Tesseract and Poppler manually.
-        echo Poppler binaries are available at:
-        echo   https://github.com/oschwartz10612/poppler-windows/releases
-        echo After installation set the POPPLER_PATH environment variable to
-        echo the poppler\bin directory.
+        echo Please install Tesseract manually:
+        echo   https://github.com/UB-Mannheim/tesseract/wiki
         pause
     )
 )

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # Systemabhängigkeiten installieren
 sudo apt-get update
-sudo apt-get install -y tesseract-ocr poppler-utils
+sudo apt-get install -y tesseract-ocr
 
 # Python-Abhängigkeiten installieren
 pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 streamlit==1.33.0
-pdf2image==1.16.3
+pypdfium2==4.24.0
 pytesseract==0.3.10
 fpdf2==2.7.6


### PR DESCRIPTION
## Summary
- replace Poppler-based conversion with pypdfium2
- simplify install scripts and docs accordingly

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pypdfium2==4.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899bdd5f034832081c93d5ea072ba00