### PR TITLE
Add direct Tesseract download fallback for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, u
      ```
      Der Batch-Installer versucht zuerst, das benötigte Systempaket über
      [Chocolatey](https://chocolatey.org) bzw. das Windows Paket-Tool
-     (`winget`) zu beziehen. Sollte kein Paketmanager vorhanden sein, kann
-     [Tesseract](https://github.com/UB-Mannheim/tesseract/wiki) auch manuell
-     installiert werden.
+     (`winget`) zu beziehen. Ist kein Paketmanager vorhanden, lädt das Skript
+     automatisch den aktuellen Installer von der UB Mannheim herunter und
+     führt ihn im Hintergrund aus. Falls der Download fehlschlägt, kann
+     [Tesseract](https://github.com/UB-Mannheim/tesseract/wiki) weiterhin
+     manuell installiert werden.
 
 Alternativ können die Python-Abhängigkeiten auch manuell installiert werden:
 ```bash

--- a/install.bat
+++ b/install.bat
@@ -16,9 +16,19 @@ if %ERRORLEVEL% EQU 0 (
         winget install -e --id UB-Mannheim.Tesseract-OCR
     ) else (
         echo Neither Chocolatey nor Winget could be found.
-        echo Please install Tesseract manually:
-        echo   https://github.com/UB-Mannheim/tesseract/wiki
-        pause
+        echo Downloading Tesseract installer...
+        set DOWNLOAD_URL=https://github.com/UB-Mannheim/tesseract/releases/latest/download/tesseract-ocr-w64-setup.exe
+        powershell -Command "Invoke-WebRequest -Uri %DOWNLOAD_URL% -OutFile tesseract-installer.exe"
+        if exist tesseract-installer.exe (
+            echo Installing Tesseract...
+            start /wait tesseract-installer.exe /SILENT
+            del tesseract-installer.exe
+        ) else (
+            echo Failed to download Tesseract installer.
+            echo Please install Tesseract manually:
+            echo   https://github.com/UB-Mannheim/tesseract/wiki
+            pause
+        )
     )
 )
 


### PR DESCRIPTION
## Summary
- download and install Tesseract in install.bat when no package manager is present
- document automatic installer download in Windows setup instructions

## Testing
- `apt-get update` *(fails: repository 'noble' is not signed)*
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899c022f548832084b2725c91626a26