### PR TITLE
Replace Tesseract with EasyOCR for portable OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PDF OCR
 
-Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, um PDF-Dateien mit Hilfe der Open-Source-OCR-Engine [Tesseract](https://github.com/tesseract-ocr/tesseract) zu verarbeiten. Hochgeladene PDFs werden seitenweise in Bilder umgewandelt, per OCR erkannt und als neue PDF mit extrahiertem Text zum Download bereitgestellt.
+Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, um PDF-Dateien mit Hilfe der reinen Python-Bibliothek [EasyOCR](https://github.com/JaidedAI/EasyOCR) zu verarbeiten. Hochgeladene PDFs werden seitenweise in Bilder umgewandelt, per OCR erkannt und als neue PDF mit extrahiertem Text zum Download bereitgestellt.
 
 ## Voraussetzungen
 
 - Python 3.10 oder neuer
-- Systempaket [`tesseract-ocr`](https://tesseract-ocr.github.io/tessdoc/Home.html) (für die OCR-Erkennung)
+
 
 ## Installation
 
@@ -23,13 +23,6 @@ Dieses Projekt bietet eine kleine [Streamlit](https://streamlit.io)-Anwendung, u
      ```
      install.bat
      ```
-     Der Batch-Installer versucht zuerst, das benötigte Systempaket über
-     [Chocolatey](https://chocolatey.org) bzw. das Windows Paket-Tool
-     (`winget`) zu beziehen. Ist kein Paketmanager vorhanden, lädt das Skript
-     automatisch den aktuellen Installer von der UB Mannheim herunter und
-     führt ihn im Hintergrund aus. Falls der Download fehlschlägt, kann
-     [Tesseract](https://github.com/UB-Mannheim/tesseract/wiki) weiterhin
-     manuell installiert werden.
 
 Alternativ können die Python-Abhängigkeiten auch manuell installiert werden:
 ```bash
@@ -46,5 +39,5 @@ Streamlit zeigt anschließend die lokale URL, unter der die Weboberfläche aufge
 
 ## Hinweise
 
-- Die Sprache für die Texterkennung (Standard: Deutsch) sowie der PSM-Modus und die DPI lassen sich in der Benutzeroberfläche anpassen.
-- Für eine korrekte OCR müssen die entsprechenden Sprachpakete von Tesseract installiert sein (z. B. `tesseract-ocr-deu`).
+- Die Sprache für die Texterkennung (Standard: Deutsch) sowie die DPI lassen sich in der Benutzeroberfläche anpassen.
+- EasyOCR erwartet ISO-639-1 Sprachcodes (z. B. `de` für Deutsch, `en` für Englisch).

--- a/install.bat
+++ b/install.bat
@@ -1,36 +1,4 @@
 @echo off
-REM Run this script with administrator rights.
-REM Installs Tesseract on Windows.  The script first tries to
-REM use Chocolatey and falls back to Winget.  If neither package manager is
-REM available, a short manual installation hint is shown.
-
-REM --- install system dependencies ---------------------------------------
-where choco >NUL 2>&1
-if %ERRORLEVEL% EQU 0 (
-    echo Installing dependencies via Chocolatey...
-    choco install -y tesseract
-) else (
-    where winget >NUL 2>&1
-    if %ERRORLEVEL% EQU 0 (
-        echo Installing dependencies via Winget...
-        winget install -e --id UB-Mannheim.Tesseract-OCR
-    ) else (
-        echo Neither Chocolatey nor Winget could be found.
-        echo Downloading Tesseract installer...
-        set DOWNLOAD_URL=https://github.com/UB-Mannheim/tesseract/releases/latest/download/tesseract-ocr-w64-setup.exe
-        powershell -Command "Invoke-WebRequest -Uri %DOWNLOAD_URL% -OutFile tesseract-installer.exe"
-        if exist tesseract-installer.exe (
-            echo Installing Tesseract...
-            start /wait tesseract-installer.exe /SILENT
-            del tesseract-installer.exe
-        ) else (
-            echo Failed to download Tesseract installer.
-            echo Please install Tesseract manually:
-            echo   https://github.com/UB-Mannheim/tesseract/wiki
-            pause
-        )
-    )
-)
 
 REM --- install python dependencies --------------------------------------
 python -m pip install --upgrade pip

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Systemabhängigkeiten installieren
-sudo apt-get update
-sudo apt-get install -y tesseract-ocr
-
 # Python-Abhängigkeiten installieren
 pip install --upgrade pip
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 streamlit==1.33.0
 pypdfium2==4.24.0
-pytesseract==0.3.10
+easyocr==1.7.1
 fpdf2==2.7.6


### PR DESCRIPTION
## Summary
- switch OCR implementation from Tesseract to EasyOCR to eliminate external dependencies
- simplify install scripts to only install Python packages
- update README and requirements accordingly

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement easyocr==1.7.1)*

------
https://chatgpt.com/codex/tasks/task_e_6899c26db414832088f64016daaa8186