### PR TITLE
Add progress bar and Ctrl+C handling to PDF OCR app

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ Streamlit zeigt anschließend die lokale URL, unter der die Weboberfläche aufge
 
 - Die Sprache für die Texterkennung (Standard: Deutsch) sowie die DPI lassen sich in der Benutzeroberfläche anpassen.
 - EasyOCR erwartet ISO-639-1 Sprachcodes (z. B. `de` für Deutsch, `en` für Englisch).
+- Während der Verarbeitung zeigt ein Ladebalken den Fortschritt der Konvertierung an.
+- Das Programm kann jederzeit über `Strg+C` in der Kommandozeile beendet werden.


### PR DESCRIPTION
## Summary
- display conversion progress through a Streamlit progress bar
- allow terminating the app anytime via SIGINT
- document progress indicator and Ctrl+C behavior

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899d288ce708320abfc50968ab85e2a