### PR TITLE
Handle FPDF byte output

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,7 +116,7 @@ def ocr_pdf(
             for wrapped in wrapped_lines:
                 for chunk in _split_to_width(pdf, wrapped):
                     pdf.multi_cell(pdf.epw, 8, chunk)
-    return pdf.output(dest="S").encode("latin-1")
+    return bytes(pdf.output())
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- fix OCR PDF generation by returning bytes from FPDF output instead of encoding

## Testing
- `python -m py_compile app.py`
- `python - <<'PY' ...` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_6899f2c9f0f48320be2db967960f3c99