### PR TITLE
Add OCR debug logging and bounding box visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ streamlit run app.py
 ```
 Streamlit zeigt anschließend die lokale URL, unter der die Weboberfläche aufgerufen werden kann.
 
+## Debug-Modus
+
+Zum Debuggen kann ein Modus aktiviert werden, der die Roh-Ergebnisse der OCR in der Konsole protokolliert und Bilder mit den erkannten Bounding-Boxes abspeichert.
+
+- Linux/macOS:
+  ```bash
+  OCR_DEBUG=1 streamlit run app.py
+  ```
+- Windows (PowerShell):
+  ```powershell
+  $env:OCR_DEBUG=1
+  streamlit run app.py
+  ```
+
+Die Debug-Bilder werden als `debug_page_<nummer>.png` im aktuellen Verzeichnis abgelegt.
+
 ## Hinweise
 
 - Die Sprache für die Texterkennung (Standard: Deutsch) sowie die DPI lassen sich in der Benutzeroberfläche anpassen.


### PR DESCRIPTION
## Summary
- log OCR results in `ocr_pdf` and save bounding boxes as debug images
- add optional debug mode configurable via `OCR_DEBUG` environment variable
- document debug mode activation in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a0212e6248320b54ab1bdb6ec22bc